### PR TITLE
Add get command to access a secret for a key

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ Options:
    - -o, --output: The output file. Defaults to [KeySpecName]Keys.swift
    - -s, --spec: An optional path to a `.yml` key spec. Defaults to `chimney.yml`.
    
+### Get
+
+As an alternative to accessing secrets at runtime via the generated file, `get` can be used to get a secret for a key. This enables build time scripts to access secrets.
+
+```
+chimney get <key>
+```
+
+Options:
+  - -s, --spec: An optional path to a `.yml` key spec. Defaults to `chimney.yml`
+
 ### Integration
 
 Once the file is generated, go ahead and add it to your project in Xcode, but also make sure to add it to your `.gitignore`:

--- a/Sources/Chimney/Error.swift
+++ b/Sources/Chimney/Error.swift
@@ -5,9 +5,12 @@ import SwiftCLI
 enum KeySpecError: Error, ProcessError {
     case missingKeySpec(Path)
     case missingKeys([String])
+    case missingKey(String)
 
     var message: String? {
         switch self {
+        case .missingKey(let key):
+            return "\("Error:", color: .red) No value found in keychain for \(key, color: .green). Run \("chimney setup", color: .magenta) to enter missing value."
             case .missingKeys(let keys):
                 return "\("Error:", color: .red) No value found in keychain for \(keys, color: .green). Run \("chimney setup", color: .magenta) to enter missing values."
             case .missingKeySpec(let path):

--- a/Sources/Chimney/GetCommand.swift
+++ b/Sources/Chimney/GetCommand.swift
@@ -1,0 +1,26 @@
+import PathKit
+import SwiftCLI
+
+class GetCommand: Command {
+    let name = "get"
+    let shortDescription = "Outputs a secret from the keychain for the key"
+
+    let spec = Key<Path>(
+        "-s",
+        "--spec",
+        description: "The path to the key spec file. Defaults to chimney.yml"
+    )
+
+    @Param var key: String
+
+    func execute() throws {
+        let keySpec = try KeySpec(path: spec.value)
+        let keyStore = KeyStore(spec: keySpec)
+
+        guard let value = keyStore[key] else {
+            throw KeySpecError.missingKey(key)
+        }
+
+        stdout <<< value
+    }
+}

--- a/Sources/Chimney/main.swift
+++ b/Sources/Chimney/main.swift
@@ -2,5 +2,5 @@ import Foundation
 import SwiftCLI
 
 let cli = CLI(name: "chimney")
-cli.commands = [SetupCommand(), GenerateCommand()]
+cli.commands = [SetupCommand(), GenerateCommand(), GetCommand()]
 cli.goAndExit()


### PR DESCRIPTION
This adds a `chimney get` command which outputs the secret for a given key. This enables chimney to be used within scripts as an alternative to the runtime usage of the Keys.swift file.

```
Usage: chimney get <key> [options]

Outputs a secret from the keychain for the key

Options:
  -h, --help            Show help information
  -s, --spec <value>    The path to the key spec file. Defaults to chimney.yml
```