### PR TITLE
Work-Around-Secure-Input-Limit-And-Update-Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Run `setup`:
 ```
 chimney setup
 ```
+or (if installed via Mint)
+```
+mint run chimney setup
+```
 
 The first time, it will ask you to provide values for each key.
 ```
@@ -71,6 +75,11 @@ Options:
 Once your keys are setup, running `generate`:
 ```
 chimney generate
+🏭 Generating MyProjectKeys.swift...
+```
+or (if installed via Mint)
+```
+mint run chimney generate
 🏭 Generating MyProjectKeys.swift...
 ```
 
@@ -98,6 +107,10 @@ As an alternative to accessing secrets at runtime via the generated file, `get` 
 
 ```
 chimney get <key>
+```
+or (if installed via Mint)
+```
+mint run chimney get <key>
 ```
 
 Options:

--- a/Sources/Chimney/GenerateCommand.swift
+++ b/Sources/Chimney/GenerateCommand.swift
@@ -40,7 +40,7 @@ class GenerateCommand: Command {
             bundlePath,
             bundlePath + relativePath
         ])
-        let environment = Environment(loader: fsLoader)    
+        let environment = Environment(loader: fsLoader)
         let rendered = try environment.renderTemplate(name: "chimney.stencil", context: context)
         try outputPath.write(rendered)
     }

--- a/Sources/Chimney/SetupCommand.swift
+++ b/Sources/Chimney/SetupCommand.swift
@@ -23,7 +23,14 @@ class SetupCommand: Command {
             for key in keys {
                 stdout <<< "❌ Keys has detected a missing keychain value."
                 stdout <<< "🔑 What is the key for \(key, color: .green)"
-                keyStore[key] = Input.readLine(prompt: ">", secure: true)
+                var input = Input.readLine(prompt: ">", secure: true)
+
+                if input.count == 128 {
+                    stdout <<< "🚨 That key was too long for secure input. Please enter it again (will be visible)."
+                    input = Input.readLine(prompt: ">", secure: false)
+                }
+
+                keyStore[key] = input
             }
         }
 

--- a/Sources/Chimney/SetupCommand.swift
+++ b/Sources/Chimney/SetupCommand.swift
@@ -25,6 +25,8 @@ class SetupCommand: Command {
                 stdout <<< "🔑 What is the key for \(key, color: .green)"
                 var input = Input.readLine(prompt: ">", secure: true)
 
+                // Working around an issue in SwiftCLI which limits secure input to 128 characters.
+                // (https://github.com/jakeheis/SwiftCLI/issues/109)
                 if input.count == 128 {
                     stdout <<< "🚨 That key was too long for secure input. Please enter it again (will be visible)."
                     input = Input.readLine(prompt: ">", secure: false)


### PR DESCRIPTION
SwiftCLI can only support secure input for items 128 characters or shorter. Commit adds a workaround to allow a value to be re-entered insecurely if it's longer than 128 characters. The README was also updated to mention Mint run command alternatives for Chimney commands (if Chimney was installed via Mint).

### To Test
Attempt to enter a key value that is 128 characters or longer. This should trigger an additional prompt to enter the key again (non-secured). Confirm that the value is not truncated in the macOS keychain.