### PR TITLE
Dummy keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ class MyProjectKeys {
 Options: 
    - -o, --output: The output file. Defaults to [KeySpecName]Keys.swift
    - -s, --spec: An optional path to a `.yml` key spec. Defaults to `chimney.yml`.
+   - -d, --dummy: Indicates if dummy keys with the value 'xxxx' should be generated instead of referencing KeyChain for the keys. Defaults to false.
    
 ### Get
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ class MyProjectKeys {
 Options: 
    - -o, --output: The output file. Defaults to [KeySpecName]Keys.swift
    - -s, --spec: An optional path to a `.yml` key spec. Defaults to `chimney.yml`.
-   - -d, --dummy: Indicates if dummy keys with the value 'xxxx' should be generated instead of referencing KeyChain for the keys. Defaults to false.
+   - -d, --dummy: Pass in a `String` that is used as a dummy value for all keys instead of referencing KeyChain for the keys.
    
 ### Get
 

--- a/Sources/Chimney/DummyKeyStore.swift
+++ b/Sources/Chimney/DummyKeyStore.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A dummy version of the `KeyStore` used to generate dummy keys instead of keys pulled from `KeychainAccess`.
+class DummyKeyStore {
+    let spec: KeySpec
+
+    init(spec: KeySpec) {
+        self.spec = spec
+    }
+
+    func generate() -> [KeyEntry] {
+        return spec.keys.map {
+            KeyEntry(name: $0, value: "xxxx")
+        }
+    }
+}

--- a/Sources/Chimney/DummyKeyStore.swift
+++ b/Sources/Chimney/DummyKeyStore.swift
@@ -2,15 +2,17 @@ import Foundation
 
 /// A dummy version of the `KeyStore` used to generate dummy keys instead of keys pulled from `KeychainAccess`.
 class DummyKeyStore {
+    let dummyValue: String
     let spec: KeySpec
 
-    init(spec: KeySpec) {
+    init(dummyValue: String, spec: KeySpec) {
+        self.dummyValue = dummyValue
         self.spec = spec
     }
 
     func generate() -> [KeyEntry] {
         return spec.keys.map {
-            KeyEntry(name: $0, value: "xxxx")
+            KeyEntry(name: $0, value: dummyValue)
         }
     }
 }

--- a/Sources/Chimney/GenerateCommand.swift
+++ b/Sources/Chimney/GenerateCommand.swift
@@ -20,14 +20,27 @@ class GenerateCommand: Command {
         description: "The output file. Defaults to [keyspec name]Keys.swift"
     )
 
+    @Flag(
+        "-d",
+        "--dummy",
+        description: "Indicates if dummy keys with the value 'xxxx' should be generated instead of referencing KeyChain for the keys. Defaults to false."
+    )
+    var dummy: Bool
+
     func execute() throws {
         let keySpec = try KeySpec(path: spec.value)
         let outputPath = (output.value ?? keySpec.outputPath).absolute()
 
         stdout <<< "🏭 Generating \(outputPath)..."
 
-        let keyStore = KeyStore(spec: keySpec)
-        let keys = try keyStore.generate()
+        let keys: [KeyEntry]
+        if dummy {
+            let dummyKeyStore = DummyKeyStore(spec: keySpec)
+            keys = dummyKeyStore.generate()
+        } else {
+            let keyStore = KeyStore(spec: keySpec)
+            keys = try keyStore.generate()
+        }
         let context: [String: Any] = [
             "name": keySpec.name,
             "keys": keys

--- a/Sources/Chimney/GenerateCommand.swift
+++ b/Sources/Chimney/GenerateCommand.swift
@@ -20,12 +20,12 @@ class GenerateCommand: Command {
         description: "The output file. Defaults to [keyspec name]Keys.swift"
     )
 
-    @Flag(
+    @Key(
         "-d",
         "--dummy",
-        description: "Indicates if dummy keys with the value 'xxxx' should be generated instead of referencing KeyChain for the keys. Defaults to false."
+        description: "Pass in a `String` that is used as a dummy value for all keys instead of referencing KeyChain for the keys."
     )
-    var dummy: Bool
+    var dummy: String?
 
     func execute() throws {
         let keySpec = try KeySpec(path: spec.value)
@@ -34,8 +34,8 @@ class GenerateCommand: Command {
         stdout <<< "🏭 Generating \(outputPath)..."
 
         let keys: [KeyEntry]
-        if dummy {
-            let dummyKeyStore = DummyKeyStore(spec: keySpec)
+        if let dummy {
+            let dummyKeyStore = DummyKeyStore(dummyValue: dummy, spec: keySpec)
             keys = dummyKeyStore.generate()
         } else {
             let keyStore = KeyStore(spec: keySpec)


### PR DESCRIPTION
This PR adds the `--dummy` flag to the generate command to generate dummy keys. This is useful for generating the keys file in cases where the actual keys should not be used or can't be accessed.


An example output when using the `--dummy "xxxx"` argument:
```
import Foundation

class FooProjectKeys {
    
    static let BarKey = "xxxx"
    
    static let FezKey = "xxxx"
    
    static let Prod_FezKey = "xxxx"
}
```